### PR TITLE
Update Marketing API version to v25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-*Upstream test files changes are not included*
+## 1.25.1
+  * Bump requests dependency from 2.32.4 to 2.34.0 [#266](https://github.com/singer-io/tap-facebook/pull/266)
+
+## 1.25.0
+  * Bump facebook_business SDK from v23.0.1 to v25.0.1 to stay ahead of v23.0 deprecation (June 9, 2026) [#265](https://github.com/singer-io/tap-facebook/pull/265)
+  * Confirmed no schema changes required: `smart_promotion_type` was never present in campaigns schema
+  * Add explicit "Job Failed" status handling in async Insights job polling; surface v25.0 error fields (`error_code`, `error_message`, `error_subcode`, `error_user_title`, `error_user_msg`)
 
 ## 1.24.0
   * Bump facebook_business SDK to v23.0.1 [#255](https://github.com/singer-io/tap-facebook/pull/255)
-  * Remove Deprecated Fields from adcreative [#255](https://github.com/singer-io/tap-facebook/pull/255) *We do not accept it as we don't need adcreative data*
+  * Remove Deprecated Fields from adcreative [#255](https://github.com/singer-io/tap-facebook/pull/255)
 
 ## 1.23.0
   * Add default value of missing pk for ads_insights_hourly_advertiser [#250](https://github.com/singer-io/tap-facebook/pull/250)
@@ -13,7 +19,7 @@
   * Bump dependency versions for twistlock compliance [#247](https://github.com/singer-io/tap-facebook/pull/247)
 
 ## 1.22.0
-  * Adds warning when 'reach' is requested for breakdown queries older than 13 months due to Meta API changes  [#245](https://github.com/singer-io/tap-facebook/pull/245) *We do not accept it as we might not have such queries*
+  * Adds warning when 'reach' is requested for breakdown queries older than 13 months due to Meta API changes  [#245](https://github.com/singer-io/tap-facebook/pull/245)
 
 ## 1.21.0
   * Bump facebook_business SDK to v21.0.5 [#242](https://github.com/singer-io/tap-facebook/pull/242)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+*Upstream test files changes are not included*
+
 ## 1.25.1
   * Bump requests dependency from 2.32.4 to 2.34.0 [#266](https://github.com/singer-io/tap-facebook/pull/266)
 
@@ -10,7 +12,7 @@
 
 ## 1.24.0
   * Bump facebook_business SDK to v23.0.1 [#255](https://github.com/singer-io/tap-facebook/pull/255)
-  * Remove Deprecated Fields from adcreative [#255](https://github.com/singer-io/tap-facebook/pull/255)
+  * Remove Deprecated Fields from adcreative [#255](https://github.com/singer-io/tap-facebook/pull/255) *We do not accept it as we don't need adcreative data*
 
 ## 1.23.0
   * Add default value of missing pk for ads_insights_hourly_advertiser [#250](https://github.com/singer-io/tap-facebook/pull/250)
@@ -19,7 +21,7 @@
   * Bump dependency versions for twistlock compliance [#247](https://github.com/singer-io/tap-facebook/pull/247)
 
 ## 1.22.0
-  * Adds warning when 'reach' is requested for breakdown queries older than 13 months due to Meta API changes  [#245](https://github.com/singer-io/tap-facebook/pull/245)
+  * Adds warning when 'reach' is requested for breakdown queries older than 13 months due to Meta API changes  [#245](https://github.com/singer-io/tap-facebook/pull/245) *We do not accept it as we might not have such queries*
 
 ## 1.21.0
   * Bump facebook_business SDK to v21.0.5 [#242](https://github.com/singer-io/tap-facebook/pull/242)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-facebook',
-      version='1.24.0',
+      version='1.25.1',
       description='Singer.io tap for extracting data from the Facebook Ads API',
       author='Stitch',
       url='https://singer.io',
@@ -12,10 +12,10 @@ setup(name='tap-facebook',
       install_requires=[
           'attrs==17.3.0',
           'backoff==2.2.1',
-          'facebook_business==23.0.1',
+          'facebook_business==25.0.1',
           'pendulum==1.2.0',
-          'requests==2.33.0',
-          'singer-python==6.0.1',
+          'requests==2.34.0',
+          'singer-python==6.8.0',
       ],
       extras_require={
           'dev': [

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -745,6 +745,18 @@ class AdsInsights(Stream):
             if status == "Job Completed":
                 return job
 
+            if status == "Job Failed":
+                error_code = job.get('error_code')
+                error_message = job.get('error_message')
+                error_subcode = job.get('error_subcode')
+                error_user_title = job.get('error_user_title')
+                error_user_msg = job.get('error_user_msg')
+                raise TapFacebookException(
+                    'Insights job {} failed. error_code={}, error_subcode={}, '
+                    'error_user_title={}, error_user_msg={}, error_message={}'.format(
+                        job_id, error_code, error_subcode,
+                        error_user_title, error_user_msg, error_message))
+
             if duration > INSIGHTS_MAX_WAIT_TO_START_SECONDS and percent_complete == 0:
                 pretty_error_message = ('Insights job {} did not start after {} seconds. ' +
                                         'This is an intermittent error and may resolve itself on subsequent queries to the Facebook API. ' +


### PR DESCRIPTION
Grabbing updates from singe.io's tap-facebook. Now, we are using Marketing API version v25.0
